### PR TITLE
Update react version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "url": "git+https://github.com/Iconscout/react-unicons.git"
   },
   "peerDependencies": {
-    "react": ">=15.0.0 <17.0.0"
+    "react": ">=15.0.0 <18.0.0"
   },
   "dependencies": {
-    "react": ">=15.0.0 <17.0.0"
+    "react": ">=15.0.0 <18.0.0"
   },
   "keywords": [
     "unicons",


### PR DESCRIPTION
The previous version notation was accurate before react team has released the react@17 and react-dom@17
Now we know these versions contain almost no breaking change at all!
So I guess it's safe to kick the can down the line till a future react@18 version :sweat_smile:


We have issues with the current version since we upgraded to new react-scripts with react@17 and we had to work around it by using the resolutions field in package.json
But I think that wouldn't be that easy to solve for guys that are using npm.